### PR TITLE
Use the Tilt name to identify the beer in the API

### DIFF
--- a/app/controllers/api/beers_controller.rb
+++ b/app/controllers/api/beers_controller.rb
@@ -6,7 +6,7 @@ module Api
     skip_before_action :verify_authenticity_token
 
     def create
-      beer = Beer.where(name: params['Beer']).first_or_create
+      beer = Beer.where(tilt_name: params['Beer']).first_or_create
       beer.beer_hourly_data_points.create!(
         temperature: params['Temp'],
         specific_gravity: params['SG']

--- a/db/migrate/20200907205348_add_tilt_name_to_beers.rb
+++ b/db/migrate/20200907205348_add_tilt_name_to_beers.rb
@@ -1,0 +1,5 @@
+class AddTiltNameToBeers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :beers, :tilt_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_012618) do
+ActiveRecord::Schema.define(version: 2020_09_07_205348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_012618) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "description"
     t.string "slug"
+    t.string "tilt_name"
     t.index ["slug"], name: "index_beers_on_slug", unique: true
   end
 

--- a/test/controllers/api/beer_controller_test.rb
+++ b/test/controllers/api/beer_controller_test.rb
@@ -5,13 +5,13 @@ require 'test_helper'
 module Api
   class BeerControllerTest < ActionDispatch::IntegrationTest
     test 'creating a beer hourly data point' do
-      beer = Beer.create(name: 'A firstly, awesome beer.')
+      beer = Beer.create(name: 'A beer.', tilt_name: 'A firstly, awesome beer.')
       post api_beer_url,
            params: {
              'Timepoint': '44073.0189925463',
              'Temp': '81.0',
              'SG': '1.036',
-             'Beer': beer.name,
+             'Beer': beer.tilt_name,
              'Color': 'RED',
              'Comment': 'jarydkrishnan@gmail.com'
            }
@@ -31,7 +31,7 @@ module Api
              'Comment': 'jarydkrishnan@gmail.com'
            }
       assert_response :success
-      beer = Beer.where(name: 'Some brand new beer').first
+      beer = Beer.where(tilt_name: 'Some brand new beer').first
       assert_not_nil beer
       assert_equal 1, beer.beer_hourly_data_points.count
       beer.destroy


### PR DESCRIPTION
The tilt requires us to have a name set correctly.

This ensures that we use the "Tilt" name to identify the beer.