### PR TITLE
Log all background jobs

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+GoodJob.preserve_job_records = true


### PR DESCRIPTION
Logs all of our `good_job` background jobs, for review in the web interface.

We also have a background task on Heroku that takes care of cleaning up all old jobs over 1 month old.