### PR TITLE
Leave the current beer out of related beers

### DIFF
--- a/app/controllers/beers_controller.rb
+++ b/app/controllers/beers_controller.rb
@@ -11,7 +11,7 @@ class BeersController < ApplicationController
 
   def show
     @beer = Beer.friendly.find(params[:id])
-    @beers = @beers.order(start_date: :desc).first(3)
+    @beers = @beers.where.not(id: @beer.id).order(start_date: :desc).first(3)
     @title = @beer.name
   end
 


### PR DESCRIPTION
Removes the current beer out of the related beers list.

Removes essentially a "duplicate" from the links list at the bottom of the page