### PR TITLE
Update to turbo and stimulus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'friendly_id'
 gem 'good_job'
 gem 'graphql'
 gem 'hiredis'
-gem 'hotwire-rails'
 gem 'image_processing'
 gem 'jbuilder'
 gem 'jsbundling-rails', '~> 1.0'
@@ -30,6 +29,8 @@ gem 'puma'
 gem 'rack-cors'
 gem 'redis'
 gem 'scout_apm'
+gem 'stimulus-rails'
+gem 'turbo-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,10 +160,6 @@ GEM
       webrick (>= 1.3)
     graphql (2.0.17)
     hiredis (0.6.3)
-    hotwire-rails (0.1.3)
-      rails (>= 6.0.0)
-      stimulus-rails
-      turbo-rails
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -227,7 +223,7 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
-    parser (3.1.2.1)
+    parser (3.2.1.0)
       ast (~> 2.4.1)
     pg (1.4.4)
     public_suffix (5.0.0)
@@ -319,7 +315,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scout_apm (5.3.2)
+    scout_apm (5.3.3)
       parser
     selectize-rails (0.12.6)
     selenium-webdriver (3.142.7)
@@ -354,12 +350,12 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
-    stimulus-rails (1.1.1)
+    stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.0)
-    turbo-rails (1.3.2)
+    turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -407,7 +403,6 @@ DEPENDENCIES
   good_job
   graphql
   hiredis
-  hotwire-rails
   image_processing
   jbuilder
   jsbundling-rails (~> 1.0)
@@ -426,6 +421,8 @@ DEPENDENCIES
   selenium-webdriver
   simplecov
   solargraph
+  stimulus-rails
+  turbo-rails
   web-console (>= 3.3.0)
   webdrivers
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,12 +1,12 @@
 // Entry point for the build script in your package.json
 import * as ActiveStorage from '@rails/activestorage';
 import * as Ujs from '@rails/ujs';
-import { Turbo } from '@hotwired/turbo-rails';
 import 'trix';
 import '@rails/actiontext';
+import "@hotwired/turbo-rails"
+
 
 import './controllers';
 
 Ujs.start();
 ActiveStorage.start();
-window.Turbo = Turbo;

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -1,6 +1,6 @@
 import { Chart,  DoughnutController, ArcElement, Tooltip } from 'chart.js';
 import 'chartjs-adapter-luxon';
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 Chart.register(DoughnutController, ArcElement, Tooltip);
 

--- a/app/javascript/controllers/hourly_chart_controller.js
+++ b/app/javascript/controllers/hourly_chart_controller.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Chart, LineController, LineElement, PointElement, LinearScale, TimeScale, Tooltip } from 'chart.js';
 import 'chartjs-adapter-luxon';
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 Chart.register(LineController, LineElement, PointElement, LinearScale, TimeScale, Tooltip);
 

--- a/app/javascript/controllers/hourly_chart_controller.js
+++ b/app/javascript/controllers/hourly_chart_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
     carboy: Number,
   }
 
-  static targets = ["canvas"]
+  static targets = ["canvas", "loading"]
 
   initialize() {
     this.pages = 1;
@@ -28,7 +28,6 @@ export default class extends Controller {
     try {
       this.error = false;
       await this.fetchPages();
-      this.renderChart();
     } catch (error) {
       this.error = true;
       console.error(error);
@@ -39,6 +38,7 @@ export default class extends Controller {
     while(this.currentPage < this.pages) {
       this.currentPage += 1;
       await this.fetchPage(this.currentPage);
+      this.renderOrUpdateChart();
     }
   }
 
@@ -52,7 +52,25 @@ export default class extends Controller {
     this.hourlyDataPoints = [...this.hourlyDataPoints, ...response.data];
   }
 
+  renderOrUpdateChart() {
+    if (this.chart) {
+      this.updateChart();
+    } else {
+      this.renderChart();
+    }
+  }
+
+  updateChart() {
+    this.chart.data.datasets[0].data = this.hourlyDataPoints;
+    this.chart.data.datasets[1].data = this.hourlyDataPoints;
+    this.chart.update();
+  }
+
   renderChart() {
+    if (this.hasLoadingTarget) {
+      this.loadingTarget.remove();
+    }
+
     const data = this.hourlyDataPoints;
     const datasets = {
       datasets: [

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,8 +1,7 @@
 // Load all the channels within this directory and all subdirectories.
 // Channel files must be named *_controller.js.
 
-import { Application } from 'stimulus';
-import { definitionsFromContext } from 'stimulus/webpack-helpers';
+import { Application } from '@hotwired/stimulus';
 import { Dropdown } from 'tailwindcss-stimulus-components';
 
 import ChartController from './chart_controller';

--- a/app/views/beers/show.html.erb
+++ b/app/views/beers/show.html.erb
@@ -31,6 +31,13 @@
           <div class="px-0 md:px-8 mt-16 md:mt-0 w-full md:w-6/12">
             <h4 class="text-center leading-5 font-medium text-gray-500 mb-4">Carboy #<%= index + 1 %></h4>
             <div data-controller="hourly-chart" data-hourly-chart-beer-value="<%= @beer.friendly_id %>" data-hourly-chart-carboy-value="<%= carboy.id %>">
+            <div class="text-center mt-16 flex justify-center" role="status" data-hourly-chart-target="loading">
+              <svg aria-hidden="true" class="w-8 h-8 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
+                <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
+              </svg>
+              <span class="sr-only">Loading...</span>
+            </div>
               <canvas data-hourly-chart-target="canvas" class="my-auto"></canvas>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,10 +30,10 @@
     <%= yield :head %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "action_text", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true, async: true %>
   </head>
 
   <body>
     <%= yield %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true, async: true %>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ]
   },
   "dependencies": {
+    "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.0.0",
     "@rails/actioncable": "^7.0.4",
     "@rails/actiontext": "^7.0.4",
@@ -46,9 +47,8 @@
     "graphql": "^15.5.0",
     "luxon": "^3.1.0",
     "sass": "^1.32.5",
-    "stimulus": "^2.0.0",
     "tailwindcss": "^3.2.4",
-    "tailwindcss-stimulus-components": "^2.1.2",
+    "tailwindcss-stimulus-components": "^3",
     "trix": "^1.3.1"
   },
   "devDependencies": {

--- a/test/javascript/controllers/chart_controller.test.js
+++ b/test/javascript/controllers/chart_controller.test.js
@@ -1,4 +1,4 @@
-import { Application } from "stimulus";
+import { Application } from "@hotwired/stimulus";
 import ChartController from "chart_controller";
 
 describe('ChartController', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,18 +389,23 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.13.tgz#64e8825bf0ce769dac94ee39d92ebe6272020dfc"
   integrity sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==
 
+"@hotwired/stimulus@>=3.0.0", "@hotwired/stimulus@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.1.tgz#e3de23623b0c52c247aba4cd5d530d257008676b"
+  integrity sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ==
+
 "@hotwired/turbo-rails@^7.0.0":
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.2.4.tgz#d155533e79c4ebdac23e8fe12697d821d5c06307"
-  integrity sha512-givDUQqaccd19BvErz1Cf2j6MXF74m0G6I75oqFJGeXAa7vwkz9nDplefVNrALCR9Xi9j9gy32xmSI6wD0tZyA==
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.3.0.tgz#422c21752509f3edcd6c7b2725bbe9e157815f51"
+  integrity sha512-fvhO64vp/a2UVQ3jue9WTc2JisMv9XilIC7ViZmXAREVwiQ2S4UC7Go8f9A1j4Xu7DBI6SbFdqILk5ImqVoqyA==
   dependencies:
-    "@hotwired/turbo" "^7.2.4"
+    "@hotwired/turbo" "^7.3.0"
     "@rails/actioncable" "^7.0"
 
-"@hotwired/turbo@^7.2.4":
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.4.tgz#0d35541be32cfae3b4f78c6ab9138f5b21f28a21"
-  integrity sha512-c3xlOroHp/cCZHDOuLp6uzQYEbvXBUVaal0puXoGJ9M8L/KHwZ3hQozD4dVeSN9msHWLxxtmPT1TlCN7gFhj4w==
+"@hotwired/turbo@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
+  integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -728,30 +733,6 @@
   integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-"@stimulus/core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
-  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
-  dependencies:
-    "@stimulus/mutation-observers" "^2.0.0"
-
-"@stimulus/multimap@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
-  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
-
-"@stimulus/mutation-observers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
-  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
-  dependencies:
-    "@stimulus/multimap" "^2.0.0"
-
-"@stimulus/webpack-helpers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
-  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
 
 "@tailwindcss/aspect-ratio@^0.4.2":
   version "0.4.2"
@@ -3321,14 +3302,6 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stimulus@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
-  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
-  dependencies:
-    "@stimulus/core" "^2.0.0"
-    "@stimulus/webpack-helpers" "^2.0.0"
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -3422,12 +3395,12 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tailwindcss-stimulus-components@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/tailwindcss-stimulus-components/-/tailwindcss-stimulus-components-2.1.2.tgz#fb4120ba2284793f7dbf348ec5d40c0a70f4b28d"
-  integrity sha512-nKTZ0VnvwBwfd7KJE4aUnoFIFhW1Q0lhqVk06pLcRm6FLFynV+xdDIxts5Dyj4ZMF7yRFdBvhLimQ71iWfxinQ==
+tailwindcss-stimulus-components@^3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tailwindcss-stimulus-components/-/tailwindcss-stimulus-components-3.0.4.tgz#598a880aed1a4966c2bf85fcc9c65fb63d02d2f0"
+  integrity sha512-kv4CHEcTvZSmthV6PseSdnW/QqKh237fZrvbNKNhWeYsTuEnOrKvdbR+3CmpuTok7L4XgEXk+XOFfo7AMhhtAA==
   dependencies:
-    stimulus "^2.0.0"
+    "@hotwired/stimulus" ">=3.0.0"
 
 tailwindcss@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
[`hotwire-rails` appears to be deprecated](https://github.com/hotwired/hotwire-rails#hotwire-for-rails-deprecated)

This moves us to Turbo and Stimulus (independent of hotwire).

This also improves the loading experience of large hourly charts.